### PR TITLE
useFetch 에러 리턴 추가,  예시 페이지 서버채팅 추가

### DIFF
--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import axios from "axios";
+import { useEffect, useState } from "react";
 
 interface BaseProps {
   url: string;
@@ -22,12 +22,14 @@ interface Return {
   loading: boolean;
   statusCode: number;
   refresh: () => void;
+  error: any;
 }
 
 const useFetch = ({ url, method, data, start }: Props): Return => {
   const [result, setResult] = useState<object>();
   const [loading, setLoading] = useState(false);
   const [statusCode, setCode] = useState(-1);
+  const [error, setError] = useState<any>({});
 
   const fetchData = async () => {
     if (loading) return;
@@ -54,40 +56,43 @@ const useFetch = ({ url, method, data, start }: Props): Return => {
     }
 
     if (method === "GET") {
-      const response = await axios.get(url, {
-        headers: headers,
-      });
-
-      setCode(response.status);
-
       try {
+        const response = await axios.get(url, {
+          headers: headers,
+        });
+
+        setCode(response.status);
+
         setResult(response.data);
-      } catch (err) {
+      } catch (error) {
+        setError(error);
         setResult({});
       }
 
       setLoading(false);
     } else if (method === "POST") {
-      const response = await axios.post(url, data, {
-        headers: headers,
-      });
-      setCode(response.status);
       try {
+        const response = await axios.post(url, data, {
+          headers: headers,
+        });
+        setCode(response.status);
         setResult(response.data);
-      } catch (err) {
+      } catch (error) {
+        setError(error);
         setResult({});
       }
 
       setLoading(false);
     } else if (method === "PATCH") {
-      const response = await axios.patch(url, data, {
-        headers: headers,
-      });
-      setCode(response.status);
-
       try {
+        const response = await axios.patch(url, data, {
+          headers: headers,
+        });
+        setCode(response.status);
+
         setResult(response.data);
-      } catch (err) {
+      } catch (error) {
+        setError(error);
         setResult({});
       }
 
@@ -106,7 +111,7 @@ const useFetch = ({ url, method, data, start }: Props): Return => {
     fetchData();
   };
 
-  return { result, loading, statusCode, refresh };
+  return { result, loading, statusCode, refresh, error };
 };
 
 export default useFetch;

--- a/src/pages/Example/index.tsx
+++ b/src/pages/Example/index.tsx
@@ -7,8 +7,18 @@ import useFireFetch from "../../hooks/useFireFetch";
 import useInput from "../../hooks/useInput";
 
 const Example = () => {
-  // 토근 저장, 채팅 서버 연결
   const token = JSON.parse(localStorage.getItem("token") as string);
+
+  useFetch({
+    url: "https://fastcampus-chat.net/chat/participate",
+    method: "PATCH",
+    data: {
+      chatId: "9fe8a1af-9c60-4937-82dd-21d6da5b9cd9",
+    },
+    start: true,
+  });
+
+  // 채팅 서버 연결
   const socket = io(
     `https://fastcampus-chat.net/chat?chatId=9fe8a1af-9c60-4937-82dd-21d6da5b9cd9`,
     {

--- a/src/pages/Example/index.tsx
+++ b/src/pages/Example/index.tsx
@@ -9,6 +9,7 @@ import useInput from "../../hooks/useInput";
 const Example = () => {
   const token = JSON.parse(localStorage.getItem("token") as string);
 
+  // 페이지 입장시 자동으로 해당 채팅방으로 입장
   useFetch({
     url: "https://fastcampus-chat.net/chat/participate",
     method: "PATCH",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,15 +15,6 @@ export default defineConfig({
       },
     ],
   },
-  build: {
-    minify: "terser",
-    terserOptions: {
-      compress: {
-        drop_console: true,
-        drop_debugger: true,
-      },
-    },
-  },
   server: {
     watch: {
       usePolling: true,


### PR DESCRIPTION
- useFetch 에러 메시지를 상태로 저장하여 리턴하도록 추가했습니다.
- 예시 페이지에 서버 채팅을 추가하였습니다. (초대 팝업 기능 때문에 임시로 만들어 놨습니다. 나중에 코드 참고하셔도 됩니다.)
```
예시 페이지 입장 시 서버 채팅방으로 자동으로 입장이 됩니다.
한번 입장한 아이디로 다시 예시 페이지로 이동 시 이미 입장했던 아이디라 콘솔에 에러가 출력 되는데 무시해도 됩니다. 
```